### PR TITLE
feat: デバイス縦横比に応じて Glass panel の min-h を条件付き適用 [LAM-16]

### DIFF
--- a/src/components/model/movie/MovieDetailSection/index.tsx
+++ b/src/components/model/movie/MovieDetailSection/index.tsx
@@ -74,7 +74,7 @@ const MovieDetailSection: React.FC<Props> = ({
           "pt-4",
           "pb-8",
           "gap-y-3",
-          "min-h-96",
+          "tall:min-h-96",
           "short:min-h-0"
         )}
       >

--- a/src/components/ui/FadeInImage/index.tsx
+++ b/src/components/ui/FadeInImage/index.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 
 export const FadeInImage = ({
   className,
+  onLoad,
   ...props
 }: ComponentProps<typeof Image>) => {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -14,9 +15,10 @@ export const FadeInImage = ({
     <Image
       alt={props.alt ?? ""}
       onLoad={(e) => {
-        // only fade in the actual image, not the blur placeholder
-        if (e.currentTarget.src.startsWith("data:")) return;
-        setIsLoaded(true);
+        if (!e.currentTarget.src.startsWith("data:")) {
+          setIsLoaded(true);
+        }
+        onLoad?.(e);
       }}
       className={clsx(
         "transition-opacity duration-1500 ease-in-out",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
     screens: {
       "lt-sm": { max: SCREENS.SM },
       short: { raw: "(max-height: 700px)" },
+      tall: { raw: "(max-aspect-ratio: 1/2)" },
     },
     extend: {
       keyframes: {


### PR DESCRIPTION
## Summary
- Tailwind に `tall` スクリーンバリアント（`max-aspect-ratio: 1/2`）を追加
- Glass content panel の `min-h-96` をデバイスの height が width の2倍を超える場合のみ適用（`tall:min-h-96`）
- `FadeInImage` の `onLoad` を外部コールバックとマージできるよう対応

## 変更内容
- `tailwind.config.js`: `tall: { raw: "(max-aspect-ratio: 1/2)" }` を screens に追加
- `MovieDetailSection`: `min-h-96` → `tall:min-h-96` に変更
- `FadeInImage`: `onLoad` prop を destructure して内部ハンドラとマージ

## Test plan
- [ ] 通常の縦向きデバイス（height ≈ 2x width 以下）で min-h-96 が適用されないこと
- [ ] 縦長デバイス（height > 2x width）で Glass panel に min-h-96 が適用されること
- [ ] `short:min-h-0` の挙動（低height画面）が引き続き正常動作すること
- [ ] `yarn lint` / `yarn test` が通ること

Closes LAM-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)