### PR TITLE
feat: ポスター画像クリックでGlass panelスライドアニメーションをトグル

### DIFF
--- a/src/components/model/movie/MovieDetailSection/index.tsx
+++ b/src/components/model/movie/MovieDetailSection/index.tsx
@@ -71,7 +71,8 @@ const MovieDetailSection: React.FC<Props> = ({
         placeholder="blur"
         blurDataURL={POSTER_BLUR_IMAGE_BASE64}
         src={getImageUrlFromMovie(isMobile, movie)}
-        className="w-full"
+        className="w-full cursor-pointer"
+        onClick={handleToggle}
         width={isMobile ? 1000 : 780}
         height={isMobile ? 1500 : 1170}
         priority


### PR DESCRIPTION
## Summary
- `MovieDetailSection` のポスター画像（`FadeInImage`）に `onClick={handleToggle}` を追加
- ポスター画像をクリックするとGlass panelが既存のドラッグハンドルと同様にスライドアニメーションでトグルされる
- `cursor-pointer` を追加してクリック可能であることをユーザーに示す

## Test plan
- [ ] 映画詳細ページを開き、ポスター画像をクリックしてGlass panelが下にスライドすることを確認
- [ ] 再度クリックしてGlass panelが元の位置に戻ることを確認
- [ ] ドラッグハンドルによるトグルも引き続き動作することを確認

Closes LAM-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)